### PR TITLE
update to use http basic access authentication

### DIFF
--- a/lib/tutum.js
+++ b/lib/tutum.js
@@ -15,7 +15,7 @@ var Tutum = function (configuration) {
   /*eslint-disable no-underscore-dangle*/
   this.configuration = util._extend(defaults, configuration);
   /*eslint-enable no-underscore-dangle*/
-  this.configuration.authorization = this.configuration.username + ':' + this.configuration.apiKey;
+  this.configuration.authorization = new Buffer(this.configuration.username + ':' + this.configuration.apiKey).toString('base64');
 
   this.request = function (method, path, params, callback) {
     var body = {};
@@ -40,7 +40,7 @@ var Tutum = function (configuration) {
       [method](url)
       .send(body)
       .set('Accept', 'application/json')
-      .set('Authorization', 'ApiKey ' + this.configuration.authorization)
+      .set('Authorization', 'Basic ' + this.configuration.authorization)
       .set('Content-Type', 'application/json')
       .end(function (err, res) {
         if (err) {

--- a/test/tutumTests.js
+++ b/test/tutumTests.js
@@ -45,9 +45,10 @@ suite('Tutum', function () {
       username: 'foo',
       apiKey: 'bar'
     };
+    var base64Result = 'Zm9vOmJhcg==';
     var tutum = new Tutum(configuration);
 
-    assert.that(tutum.configuration.authorization, is.equalTo(configuration.username + ':' + configuration.apiKey));
+    assert.that(tutum.configuration.authorization, is.equalTo(base64Result));
     done();
   });
 


### PR DESCRIPTION
Tutum updated their authentication recently which broke this module. This change updates to match [their new model](https://docs.tutum.co/v2/api/?http#rest-api).